### PR TITLE
Implement FastAPI invoice service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# 手动开票服务使用说明
+
+本项目实现了一个基于 **FastAPI** 和 **SQLite** 的简易开票服务，支持根据用户提供的商品或服务信息生成发票并导出 PDF 文件。
+
+## 安装与运行
+1. 进入项目目录，确保使用 Python 3.11 及以上版本。
+2. 由于环境限制，项目已内置最简易的 PDF 生成逻辑，无需额外安装第三方库。
+3. 启动服务：
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## API 说明
+### `POST /invoices`
+创建发票并返回结果。
+
+请求示例：
+```json
+{
+  "items": [
+    {"name": "ItemA", "quantity": 2, "unit_price": 10.0},
+    {"name": "ItemB", "quantity": 1, "unit_price": 20.0}
+  ],
+  "notes": "示例备注"
+}
+```
+
+返回示例：
+```json
+{
+  "id": 1,
+  "subtotal": 40.0,
+  "total_tax": 6.0,
+  "total": 46.0,
+  "pdf_path": "invoices/invoice_1.pdf",
+  "items": [
+    {"name": "ItemA", "quantity": 2, "unit_price": 10.0, "total": 20.0},
+    {"name": "ItemB", "quantity": 1, "unit_price": 20.0, "total": 20.0}
+  ]
+}
+```
+
+### `GET /invoices/{id}`
+下载生成的 PDF 文件。
+
+## 测试
+在项目根目录运行：
+```bash
+pytest
+```
+
+## 目录结构
+- `app/`：核心代码
+- `tests/`：单元测试
+- `invoice_service_requirements.md`：需求文档
+

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import List
+
+from .database import get_connection
+from .models import InvoiceIn, ItemIn, DEFAULT_TAX_RATE
+
+
+def create_invoice(data: InvoiceIn) -> int:
+    conn = get_connection()
+    cursor = conn.cursor()
+    subtotal = sum(item.quantity * item.unit_price for item in data.items)
+    tax_rate = data.tax_rate if data.tax_rate is not None else DEFAULT_TAX_RATE
+    total_tax = subtotal * tax_rate
+    total = subtotal + total_tax
+    cursor.execute(
+        "INSERT INTO invoices(date, tax_rate, subtotal, total_tax, total, notes) "
+        "VALUES(?,?,?,?,?,?)",
+        (
+            datetime.utcnow().isoformat(),
+            tax_rate,
+            subtotal,
+            total_tax,
+            total,
+            data.notes,
+        ),
+    )
+    invoice_id = cursor.lastrowid
+    for item in data.items:
+        item_total = item.quantity * item.unit_price
+        cursor.execute(
+            "INSERT INTO items(invoice_id, name, quantity, unit_price, total) "
+            "VALUES(?,?,?,?,?)",
+            (
+                invoice_id,
+                item.name,
+                item.quantity,
+                item.unit_price,
+                item_total,
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return invoice_id
+
+
+def get_invoice(invoice_id: int):
+    conn = get_connection()
+    cursor = conn.cursor()
+    invoice = cursor.execute(
+        "SELECT * FROM invoices WHERE id=?", (invoice_id,)
+    ).fetchone()
+    items = cursor.execute(
+        "SELECT name, quantity, unit_price, total FROM items WHERE invoice_id=?",
+        (invoice_id,),
+    ).fetchall()
+    conn.close()
+    return invoice, items

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,41 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path('invoice.db')
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS invoices (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,
+            tax_rate REAL NOT NULL,
+            subtotal REAL NOT NULL,
+            total_tax REAL NOT NULL,
+            total REAL NOT NULL,
+            notes TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            invoice_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            unit_price REAL NOT NULL,
+            total REAL NOT NULL,
+            FOREIGN KEY(invoice_id) REFERENCES invoices(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from pathlib import Path
+
+from .database import init_db
+from .models import InvoiceIn, InvoiceOut, ItemOut
+from .crud import create_invoice, get_invoice
+from .pdf_utils import generate_invoice_pdf
+
+init_db()
+app = FastAPI(title="Invoice Service")
+
+PDF_DIR = Path('invoices')
+PDF_DIR.mkdir(exist_ok=True)
+
+@app.post('/invoices', response_model=InvoiceOut)
+def create_invoice_endpoint(data: InvoiceIn):
+    invoice_id = create_invoice(data)
+    invoice, items = get_invoice(invoice_id)
+    text_lines = [
+        f"Invoice ID: {invoice['id']}",
+        f"Date: {invoice['date']}",
+    ]
+    for item in items:
+        text_lines.append(
+            f"{item['name']} x{item['quantity']} @ {item['unit_price']} = {item['total']}"
+        )
+    text_lines.append(f"Subtotal: {invoice['subtotal']}")
+    text_lines.append(f"Tax: {invoice['total_tax']}")
+    text_lines.append(f"Total: {invoice['total']}")
+    if invoice['notes']:
+        text_lines.append(f"Notes: {invoice['notes']}")
+
+    pdf_path = PDF_DIR / f"invoice_{invoice_id}.pdf"
+    generate_invoice_pdf(text_lines, str(pdf_path))
+
+    response_items = [ItemOut(**dict(row)) for row in items]
+    return InvoiceOut(
+        id=invoice['id'],
+        subtotal=invoice['subtotal'],
+        total_tax=invoice['total_tax'],
+        total=invoice['total'],
+        pdf_path=str(pdf_path),
+        items=response_items,
+    )
+
+
+@app.get('/invoices/{invoice_id}', response_class=FileResponse)
+def get_invoice_pdf(invoice_id: int):
+    pdf_path = PDF_DIR / f"invoice_{invoice_id}.pdf"
+    if not pdf_path.exists():
+        raise HTTPException(status_code=404, detail="Invoice not found")
+    return FileResponse(str(pdf_path), media_type='application/pdf')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel, Field, validator
+from typing import List, Optional
+
+DEFAULT_TAX_RATE = 0.15
+
+class ItemIn(BaseModel):
+    name: str
+    quantity: int = Field(gt=0)
+    unit_price: float = Field(gt=0)
+    tax_rate: Optional[float] = None
+
+    @validator('tax_rate', pre=True, always=True)
+    def set_tax_rate(cls, v):
+        return DEFAULT_TAX_RATE if v is None else v
+
+class InvoiceIn(BaseModel):
+    items: List[ItemIn]
+    notes: Optional[str] = None
+    tax_rate: Optional[float] = None
+
+    @validator('tax_rate', pre=True, always=True)
+    def set_tax_rate(cls, v):
+        return DEFAULT_TAX_RATE if v is None else v
+
+class ItemOut(BaseModel):
+    name: str
+    quantity: int
+    unit_price: float
+    total: float
+
+class InvoiceOut(BaseModel):
+    id: int
+    subtotal: float
+    total_tax: float
+    total: float
+    pdf_path: str
+    items: List[ItemOut]
+

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from typing import List
+
+# Minimal PDF generator based on PDF specification
+
+def _build_pdf(text_lines: List[str]) -> bytes:
+    objects = []
+    offsets = []
+
+    def add_obj(content: str) -> int:
+        offsets.append(sum(len(o) for o in objects))
+        objects.append(content)
+        return len(offsets)
+
+    # object 1: catalog
+    add_obj("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    # object 2: pages
+    add_obj("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+
+    # build page content stream
+    contents = "BT\n/F1 12 Tf\n"
+    y = 750
+    for line in text_lines:
+        safe = line.replace('(', r'\\(').replace(')', r'\\)')
+        contents += f"1 0 0 1 50 {y} Tm ({safe}) Tj\n"
+        y -= 20
+    contents += "ET"
+
+    stream = f"4 0 obj\n<< /Length {len(contents)} >>\nstream\n{contents}\nendstream\nendobj\n"
+
+    # object 3: page
+    add_obj(
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] "
+        "/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+    )
+    add_obj(stream)
+    # object 5: font
+    add_obj("5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+    # build xref table
+    xref_start = sum(len(o) for o in objects)
+    xref = ["xref\n0 {0}\n0000000000 65535 f \n".format(len(objects)+1)]
+    for off in offsets:
+        xref.append(f"{off:010d} 00000 n \n")
+    xref_table = ''.join(xref)
+
+    trailer = (
+        f"trailer\n<< /Size {len(objects)+1} /Root 1 0 R >>\nstartxref\n" +
+        f"{xref_start}\n%%EOF"
+    )
+
+    pdf_content = ''.join(objects) + xref_table + trailer
+    return pdf_content.encode('latin1')
+
+
+def generate_invoice_pdf(text_lines: List[str], path: str):
+    pdf_bytes = _build_pdf(text_lines)
+    with open(path, 'wb') as f:
+        f.write(pdf_bytes)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from pathlib import Path
+
+from app.database import init_db
+from app.crud import create_invoice, get_invoice
+from app.models import InvoiceIn, ItemIn
+from app.pdf_utils import generate_invoice_pdf
+from app.main import PDF_DIR
+
+init_db()
+
+
+def test_create_invoice(tmp_path):
+    PDF_DIR.mkdir(exist_ok=True)
+    data = InvoiceIn(
+        items=[ItemIn(name="ItemA", quantity=2, unit_price=10.0),
+               ItemIn(name="ItemB", quantity=1, unit_price=20.0)],
+        notes="test",
+    )
+    invoice_id = create_invoice(data)
+    invoice, items = get_invoice(invoice_id)
+    pdf_path = PDF_DIR / f"invoice_{invoice_id}.pdf"
+    generate_invoice_pdf(["test"], str(pdf_path))
+
+    assert invoice["subtotal"] == 40.0
+    assert round(invoice["total_tax"], 2) == 6.0
+    assert round(invoice["total"], 2) == 46.0
+    assert pdf_path.exists()


### PR DESCRIPTION
## Summary
- implement minimal FastAPI invoice API with SQLite backend
- add simple PDF generator
- include requirement-based unit test
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b9a2b86c832a9f360473eec58958